### PR TITLE
Update Talisman version to v1.11.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "husky-talisman",
-  "version": "2.0.1",
-  "description": "Allow running of the Thoughtworks Talisman tool via node",
+  "version": "3.0.0",
+  "description": "Allow running of the ThoughtWorks Talisman tool via node",
   "main": "index.js",
   "scripts": {
     "build": "pack build",

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ export const { arch, platform } = process
 
 export const ACCEPTABLE_INPUT = {
   PRE_COMMIT: 'pre-commit',
-  POST_COMMIT: 'post-commit',
+  PRE_PUSH: 'pre-push',
   INSTALL: 'install'
 }
 
@@ -44,7 +44,7 @@ export const MESSAGES = {
 }
 
 export const VERSION_LOG = '.talisman_version'
-export const TALISMAN_VERSION = 'v0.4.3'
+export const TALISMAN_VERSION = 'v1.11.0'
 export const PACKAGE_NAME = 'husky-talisman'
 
 const BINARY_NAME = `talisman${isWindows ? '.exe' : ''}`

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ export async function run (args) {
 
         break
 
-      case ACCEPTABLE_INPUT.POST_COMMIT:
-        console.log('husky-talisman >', ACCEPTABLE_INPUT.POST_COMMIT)
+      case ACCEPTABLE_INPUT.PRE_PUSH:
+        console.log('husky-talisman >', ACCEPTABLE_INPUT.PRE_PUSH)
         await runner(argument)
 
         break


### PR DESCRIPTION
The talisman version used in this package was old and crucially misses out on some good features introduced later, like [Language Scopes](https://github.com/thoughtworks/talisman#ignoring-files-by-specifying-language-scope) which removes a lot of pain.

Since the newer version of talisman does not support **post-commit** and rather uses **pre-push**, I believe this would be a breaking change so have bumped up the version to 3.